### PR TITLE
Replace validate deprecated functions with data types

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,15 +28,15 @@
 
 class winlogbeat (
   $major_version        = undef,
-  $package_ensure       = $winlogbeat::params::package_ensure,
+  String $package_ensure       = $winlogbeat::params::package_ensure,
   $service_ensure       = $winlogbeat::params::service_ensure,
   $service_enable       = $winlogbeat::params::service_enable,
   $service_provider     = $winlogbeat::params::service_provider,
-  $registry_file        = $winlogbeat::params::registry_file,
+  String $registry_file        = $winlogbeat::params::registry_file,
   $config_file          = $winlogbeat::params::config_file,
-  $outputs              = $winlogbeat::params::outputs,
+  Hash $outputs              = $winlogbeat::params::outputs,
   $shipper              = $winlogbeat::params::shipper,
-  $logging              = $winlogbeat::params::logging,
+  Hash $logging              = $winlogbeat::params::logging,
   $run_options          = $winlogbeat::params::run_options,
   $conf_template        = undef,
   $download_url         = undef,
@@ -52,12 +52,10 @@ class winlogbeat (
   $fields_under_root    = $winlogbeat::params::fields_under_root,
   $metrics              = undef,
   #### End v5 only ####
-  $event_logs           = {},
-  $event_logs_merge     = false,
+  Hash $event_logs           = {},
+  Boolean $event_logs_merge     = false,
   $proxy_address        = undef,
 ) inherits winlogbeat::params {
-
-  validate_bool($event_logs_merge)
 
   if $major_version == undef and getvar('::winlogbeat_version') == undef {
     $real_version = '5'
@@ -100,10 +98,7 @@ class winlogbeat (
     warning('You\'ve specified a non-standard config_file location - winlogbeat may fail to start unless you\'re doing something to fix this')
   }
 
-  validate_hash($outputs, $logging, $event_logs_final)
-  validate_string($registry_file, $package_ensure)
-
-  if(!empty($proxy_address)){
+   if(!empty($proxy_address)){
     validate_re($proxy_address, ['^(http(?:s)?\:\/\/[a-zA-Z0-9]+(?:(?:\.|\-)[a-zA-Z0-9]+)+(?:\:\d+)?(?:\/[\w\-]+)*(?:\/?|\/\w+\.[a-zA-Z]{2,4}(?:\?[\w]+\=[\w\-]+)?)?(?:\&[\w]+\=[\w\-]+)*)$'], 'ERROR: You must enter a proxy url in a valid format i.e. http://proxy.net:3128')
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

validate_* function from the puppetlabs/stdlib are deprecated and should be replaced by a call to validate_legacy or using data types.

```
Warning: This method is deprecated, please use the stdlib validate_legacy function,
                    with Stdlib::Compat::Bool. There is further documentation for validate_legacy function in the README. at ["C:/ProgramData/PuppetLabs/cod
e/environments/production/modules/winlogbeat/manifests/init.pp", 60]:
   (at C:/ProgramData/PuppetLabs/code/environments/production/modules/stdlib/lib/puppet/functions/deprecation.rb:28:in `deprecation')
Warning: This method is deprecated, please use the stdlib validate_legacy function,
                    with Stdlib::Compat::Hash. There is further documentation for validate_legacy function in the README. at ["C:/ProgramData/PuppetLabs/cod
e/environments/production/modules/winlogbeat/manifests/init.pp", 103]:
   (at C:/ProgramData/PuppetLabs/code/environments/production/modules/stdlib/lib/puppet/functions/deprecation.rb:28:in `deprecation')
Warning: This method is deprecated, please use the stdlib validate_legacy function,
                    with Stdlib::Compat::String. There is further documentation for validate_legacy function in the README. at ["C:/ProgramData/PuppetLabs/c
ode/environments/production/modules/winlogbeat/manifests/init.pp", 104]:
   (at C:/ProgramData/PuppetLabs/code/environments/production/modules/stdlib/lib/puppet/functions/deprecation.rb:28:in `deprecation')
```
The params have been assigned a type based on the validate_type function that was used before.
