### PR TITLE
v6 and v7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The `winlogbeat` module depends on:
 
 ### Beginning with winlogbeat
 
-`winlogbeat` can be installed with `puppet module install skynetsolutions-winlogbeat` (or with r10k, librarian-puppet, etc.)
+`winlogbeat` can be installed with `puppet module install puppet-winlogbeat` (or with r10k, librarian-puppet, etc.)
 
 The only required parameter, other than which event logs to ship, is the `outputs` parameter.
 

--- a/lib/facter/winlogbeat_version.rb
+++ b/lib/facter/winlogbeat_version.rb
@@ -1,8 +1,11 @@
 require 'facter'
 Facter.add('winlogbeat_version') do
-  confine :kernel => %w[Windows] # rubocop:disable Style/HashSyntax
+  confine :kernel => 'Windows' # rubocop:disable Style/HashSyntax
   if File.exist?('c:\Program Files\Winlogbeat\winlogbeat.exe')
-    winlogbeat_version = Facter::Util::Resolution.exec('"c:\Program Files\Winlogbeat\winlogbeat.exe" --version')
+    winlogbeat_version = Facter::Util::Resolution.exec('"c:\Program Files\Winlogbeat\winlogbeat.exe" version')
+    if winlogbeat_version.empty?
+      winlogbeat_version = Facter::Util::Resolution.exec('"c:\Program Files\Winlogbeat\winlogbeat.exe" --version')
+    end
   end
   setcode do
     %r{^winlogbeat version ([^\s]+)?}.match(winlogbeat_version)[1] unless winlogbeat_version.nil?

--- a/lib/facter/winlogbeat_version.rb
+++ b/lib/facter/winlogbeat_version.rb
@@ -2,6 +2,7 @@ require 'facter'
 Facter.add('winlogbeat_version') do
   confine :kernel => 'Windows' # rubocop:disable Style/HashSyntax
   if File.exist?('c:\Program Files\Winlogbeat\winlogbeat.exe')
+    # Version 5.x and prior use --version syntax, 6.0 and newer uses just the version keyword. This check supports both versions
     winlogbeat_version = Facter::Util::Resolution.exec('"c:\Program Files\Winlogbeat\winlogbeat.exe" version')
     if winlogbeat_version.empty?
       winlogbeat_version = Facter::Util::Resolution.exec('"c:\Program Files\Winlogbeat\winlogbeat.exe" --version')

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,9 +18,9 @@ class winlogbeat::config {
   })
 
   if versioncmp($winlogbeat::real_version, '6') >= 0 {
-    $real_validate_cmd = 'test config'
+    $validate_cmd = 'test config'
   } else {
-    $real_validate_cmd = '-N -configtest'
+    $validate_cmd = '-N -configtest'
   }
 
   case $::kernel {
@@ -31,7 +31,7 @@ class winlogbeat::config {
         ensure       => file,
         path         => $winlogbeat::config_file,
         content      => template($winlogbeat::real_conf_template),
-        validate_cmd => "\"${winlogbeat_path}\" ${real_validate_cmd} -c \"%\"",
+        validate_cmd => "\"${winlogbeat_path}\" ${validate_cmd} -c \"%\"",
         notify       => Service['winlogbeat'],
       }
     } # end Windows

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,6 +17,12 @@ class winlogbeat::config {
     'runoptions'        => $winlogbeat::run_options,
   })
 
+  if versioncmp($winlogbeat::real_version, '6') >= 0 {
+    $real_validate_cmd = "test config"
+  } else {
+    $real_validate_cmd = "-N -configtest"
+  }
+
   case $::kernel {
     'Windows' : {
       $cmd_install_dir = regsubst($winlogbeat::install_dir, '/', '\\', 'G')
@@ -25,7 +31,7 @@ class winlogbeat::config {
         ensure       => file,
         path         => $winlogbeat::config_file,
         content      => template($winlogbeat::real_conf_template),
-        validate_cmd => "\"${winlogbeat_path}\" -N -configtest -c \"%\"",
+        validate_cmd => "\"${winlogbeat_path}\" ${real_validate_cmd} -c \"%\"",
         notify       => Service['winlogbeat'],
       }
     } # end Windows

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,9 +18,9 @@ class winlogbeat::config {
   })
 
   if versioncmp($winlogbeat::real_version, '6') >= 0 {
-    $real_validate_cmd = "test config"
+    $real_validate_cmd = 'test config'
   } else {
-    $real_validate_cmd = "-N -configtest"
+    $real_validate_cmd = '-N -configtest'
   }
 
   case $::kernel {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,7 +77,7 @@ class winlogbeat (
     } else {
       $real_conf_template = "${module_name}/winlogbeat1.yml.erb"
     }
-  } elsif $real_version == '5' {
+  } elsif $real_version == '5' or $real_version == '6' or $real_version == '7' {
     if $use_generic_template {
       $real_conf_template = "${module_name}/winlogbeat1.yml.erb"
     } else {


### PR DESCRIPTION
#### Pull Request (PR) description
Provides support for WinLogBeat v6 and v7. This achieves the same v7 compatibility as #33 but it also supports v6. More importantly it does not set `real_version` to `5` when the real version is actually 6 or 7.

Oh this PR also fixes a bug in the docs with the name of the module since it changed owners.