### PR TITLE
Add ability to use http addresses in download_url

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,7 +4,7 @@ class winlogbeat::install {
   # that in the future as it would greatly simplify this code and basically reduce it to
   # one package resource with type => chocolatey....
 
-  $filename = regsubst($winlogbeat::real_download_url, '^https.*\/([^\/]+)\.[^.].*', '\1')
+  $filename = regsubst($winlogbeat::real_download_url, '^https?.*\/([^\/]+)\.[^.].*', '\1')
   $foldername = 'Winlogbeat'
   $zip_file = join([$winlogbeat::tmp_dir, "${filename}.zip"], '/')
   $install_folder = join([$winlogbeat::install_dir, $foldername], '/')


### PR DESCRIPTION
#### Pull Request (PR) description
Modifies the regex used to generate $filename by allowing http and https addresses.  This is a simple fix that doesn't change any logic, but allows the regex to generate the $filename when a http address is used.  Previously, using an http address generated the below error:

    Error: Could not set 'present' on ensure: Invalid argument @ dir_s_mkdir - C:/Windows/Temp/http: (file: 
    /etc/puppetlabs/code/environments/production/modules/winlogbeat/manifests/install.pp, line: 27)
    Error: Could not set 'present' on ensure: Invalid argument @ dir_s_mkdir - C:/Windows/Temp/http: (file: 
    /etc/puppetlabs/code/environments/production/modules/winlogbeat/manifests/install.pp, line: 27) 
    Wrapped exception:
    Invalid argument @ dir_s_mkdir - C:/Windows/Temp/http:
    Error: /Stage[main]/Winlogbeat::Install/Archive[C:/Windows/Temp/http://repo.claytonkendall.com/beats/winlogbeat-oss-7.10.2- 
    windows-x86_64.zip.zip]/ensure: change from 'absent' to 'present' failed: Could not set 'present' on ensure: Invalid argument 
    @ dir_s_mkdir - C:/Windows/Temp/http: (file: 
    /etc/puppetlabs/code/environments/production/modules/winlogbeat/manifests/install.pp, line: 27)

Fixes #40
