### PR TITLE
Remove depricated validate_*

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -25,7 +25,7 @@ class winlogbeat::config {
   }
   if (versioncmp($winlogbeat::real_version, '7') < 0) {
     $winlogbeat_config['winlogbeat']['event_logs'].each | $k,$v | {
-      if has_key($v,'processors') {
+      if 'processors' in $v {
         fail("winlogbeat versions < 7 do not support processors key within an event_log entry\n 'processors' key present in ${k}")
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,11 +99,11 @@ class winlogbeat (
     warning('You\'ve specified a non-standard config_file location - winlogbeat may fail to start unless you\'re doing something to fix this')
   }
 
-  validate_hash($outputs, $logging, $event_logs_final)
-  validate_string($registry_file, $package_ensure)
+  validate_legacy(Hash, 'validate_hash', $outputs, $logging, $event_logs_final)
+  validate_legacy(String, 'validate_string', $registry_file, $package_ensure)
 
   if(!empty($proxy_address)) {
-    validate_re($proxy_address, ['^(http(?:s)?\:\/\/[a-zA-Z0-9]+(?:(?:\.|\-)[a-zA-Z0-9]+)+(?:\:\d+)?(?:\/[\w\-]+)*(?:\/?|\/\w+\.[a-zA-Z]{2,4}(?:\?[\w]+\=[\w\-]+)?)?(?:\&[\w]+\=[\w\-]+)*)$'], 'ERROR: You must enter a proxy url in a valid format i.e. http://proxy.net:3128')
+    validate_legacy(String, 'validate_re', $proxy_address, ['^(http(?:s)?\:\/\/[a-zA-Z0-9]+(?:(?:\.|\-)[a-zA-Z0-9]+)+(?:\:\d+)?(?:\/[\w\-]+)*(?:\/?|\/\w+\.[a-zA-Z]{2,4}(?:\?[\w]+\=[\w\-]+)?)?(?:\&[\w]+\=[\w\-]+)*)$'], 'ERROR: You must enter a proxy url in a valid format i.e. http://proxy.net:3128')
   }
   contain winlogbeat::install
   contain winlogbeat::config

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,7 +56,7 @@ class winlogbeat (
   $event_logs_merge     = false,
   $proxy_address        = undef,
 ) inherits winlogbeat::params {
-  validate_bool($event_logs_merge)
+  validate_legacy(Boolean, 'validate_bool', $event_logs_merge)
 
   if $major_version == undef and getvar('winlogbeat_version') == undef {
     $real_version = '5'


### PR DESCRIPTION
#### Pull Request (PR) description
`validate_*` has been deprecated as it is now covered by native Puppet data types and thus was removed from the latest `stdlib` [9.0.0](https://forge.puppet.com/modules/puppetlabs/stdlib/9.0.0/changelog#changed) causing a `Evaluation Error: Unknown function: 'validate_*'` error.

